### PR TITLE
path.relative doesn't work as expected

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,8 @@ module.exports = function (opt) {
                 destCss = group ? rename(opt.destCSS, group) : opt.destCSS,
                 destCssDir = path.dirname(destCss),
                 destImgDir = path.dirname(destImg),
-                imgPath = (group ? rename(opt.imgPath, group) : opt.imgPath) || path.relative(destCss, destImg);
+                imgPath = (group ? rename(opt.imgPath, group) : opt.imgPath) || path.relative(path.dirname(destCss), path.dirname(destImg));
+                imgPath = imgPath += '/' + path.basename(destImg);
 
             async.parallel([
                 function (cb) {


### PR DESCRIPTION
When passing file paths to path.relative it generates a path that I wouldn't expect. Better to use just the dirname of the file instead.

If I have a generated folder:

```
dist
 -- img
   -- sprite.png
 -- css
   -- sprite.css
```

I would expect the image path to be `../img/sprite.png` and not `../../img/sprite.png` which is what is happening now.
